### PR TITLE
Change URLs for remote data to avoid jefferislab.org redirect

### DIFF
--- a/inst/tests/test-nblast.R
+++ b/inst/tests/test-nblast.R
@@ -1,7 +1,7 @@
 context("Blasting")
 
 library(nat)
-kcs20 <- read.neuronlistfh('http://jefferislab.org/si/nblast/flycircuit/kcs20.rds', getOption('flycircuit.datadir'), quiet=TRUE)
+kcs20 <- read.neuronlistfh('http://flybrain.mrc-lmb.cam.ac.uk/si/nblast/flycircuit/kcs20.rds', getOption('flycircuit.datadir'), quiet=TRUE)
 
 op=options(flycircuit.scoremat = 'kcs20scores')
 

--- a/inst/tests/test-plotting.R
+++ b/inst/tests/test-plotting.R
@@ -1,7 +1,7 @@
 context("Plotting")
 
 library(nat)
-kcs20 <- read.neuronlistfh('http://jefferislab.org/si/nblast/flycircuit/kcs20.rds', getOption('flycircuit.datadir'), quiet=TRUE)
+kcs20 <- read.neuronlistfh('http://flybrain.mrc-lmb.cam.ac.uk/si/nblast/flycircuit/kcs20.rds', getOption('flycircuit.datadir'), quiet=TRUE)
 op=options(nat.default.neuronlist = 'kcs20', flycircuit.scoremat = 'kcs20scores')
 
 open3d()

--- a/vignettes/quick-start.Rmd
+++ b/vignettes/quick-start.Rmd
@@ -4,7 +4,7 @@
 -->
 
 # Quick-start guide
-Data for various neurons can be downloaded from jefferislab.org and analysed using this package. The data include information on the location of the neurons in 3D space, details on innervation in different neuropils, and NBLAST scores. This quick-start guide is designed to give a brief examples of a subset of the analyses that can be carried out using this package, using an example dataset of 20 Kenyon cells.
+Data for various neurons can be downloaded from flybrain.mrc-lmb.cam.ac.uk and analysed using this package. The data include information on the location of the neurons in 3D space, details on innervation in different neuropils, and NBLAST scores. This quick-start guide is designed to give a brief examples of a subset of the analyses that can be carried out using this package, using an example dataset of 20 Kenyon cells.
 
 ## Set up environment
 ```{r setup, message=FALSE, warning=FALSE}
@@ -29,7 +29,7 @@ options(flycircuit.localroot = '/my/favourite/directory')
 ```
 For example, you may wish to do this if you want to cluster all of the neurons in the dataset, therefore needing to download the 2 GB all by all score matrix. To download and load this matrix, you would need to run:
 ```{r download-huge-matrix, eval=FALSE}
-fc_download_data('http://jefferislab.org/si/nblast/flycircuit/abc2.normdmat.desc', type='bigmat')
+fc_download_data('http://flybrain.mrc-lmb.cam.ac.uk/si/nblast/flycircuit/abc2.normdmat.desc', type='bigmat')
 fc_attach_bigmat('abc2.normdmat')
 ```
 
@@ -47,7 +47,7 @@ kcs20scores[1:5, 1:5]
 At the moment we have the NBLAST scores for the Kenyon cells, but no other information about them. Let's download some.
 ```{r download-kc-info}
 # Download the data
-kcs20 <- read.neuronlistfh('http://jefferislab.org/si/nblast/flycircuit/kcs20.rds', getOption('flycircuit.datadir'))
+kcs20 <- read.neuronlistfh('http://flybrain.mrc-lmb.cam.ac.uk/si/nblast/flycircuit/kcs20.rds', getOption('flycircuit.datadir'))
 ```
 
 Now we can plot these 20 neurons and see where they are located in the brain:


### PR DESCRIPTION
`download.file` periodically decides it does not want to work with the redirect set up from `jefferislab.org` to `flybrain.mrc-lmb.cam.ac.uk`, as used in `read.neuronlist`, etc. in [nat](https://github.com/jefferis/nat). Until this issue is solved, this works around it by changing the URLs to the redirect target, namely `flybrain.mrc-lmb.cam.ac.uk`.
