### PR TITLE
Tell Travis to output log file if build fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ env:
     - _R_CHECK_FORCE_SUGGESTS_=0
     - DISPLAY=:99.0
 after_failure:
-  - cat /home/travis/build/ajdm/flycircuit/flycircuit.Rcheck/00check.log
+  - cat $TRAVIS_BUILD_DIR/flycircuit.Rcheck/00check.log


### PR DESCRIPTION
This should be useful for diagnosis when `R CMD build` fails due to treating warnings as errors.
