### PR TITLE
Tell Travis to build vignettes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ notifications:
     on_failure: change
 env:
   - global:
+    - R_BUILD_ARGS='--no-manual'
+    - R_CHECK_ARGS='--no-manual --as-cran'
     - WARNINGS_ARE_ERRORS=1
     - _R_CHECK_FORCE_SUGGESTS_=0
     - DISPLAY=:99.0


### PR DESCRIPTION
Currently, the Travis build will fail with `WARNINGS_ARE_ERRORS` set to `1` as there is no PDF version of the vignette in the package and one will not be created with the default build arguments supplied by [r-travis](https://github.com/craigcitro/r-travis). This changes the `R CMD build` arguments to ensure the vignette is built, and so the Travis build passes.
